### PR TITLE
WIP: Fix RegisterForNavigationOnPlatform

### DIFF
--- a/Source/Xamarin/Prism.Forms/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/IContainerRegistryExtensions.cs
@@ -1,6 +1,7 @@
-﻿using Prism.Mvvm;
+using Prism.Mvvm;
 using Prism.Navigation;
 using System;
+using System.Linq;
 using Xamarin.Forms;
 
 namespace Prism.Ioc
@@ -125,14 +126,17 @@ namespace Prism.Ioc
         {
             if (string.IsNullOrWhiteSpace(name))
                 name = typeof(TView).Name;
-
-            foreach (var platform in platforms)
+            
+            var platform = platforms.LastOrDefault(x => Device.RuntimePlatform == x.RuntimePlatform.ToString());
+                
+            if(platform == null)
             {
-                if (Device.RuntimePlatform == platform.RuntimePlatform.ToString())
-                    containerRegistry.RegisterForNavigationWithViewModel<TViewModel>(platform.ViewType, name);
+                containerRegistry.RegisterForNavigation<TView, TViewModel>(name);
             }
-
-            containerRegistry.RegisterForNavigation<TView, TViewModel>(name);
+            else
+            {
+                containerRegistry.RegisterForNavigationWithViewModel<TViewModel>(platform.ViewType, name);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
﻿### Description of Change ###

According to the examples in the docs calling RegisterForNavigationOnPlatform should register a different view if the platform is supplied in the platforms parameter, otherwise the default view should be registered.

Currently the default view is *always* registered instead of the platform view. As last registration wins.

### Bugs Fixed ###

Platform View registration now works per description.

### API Changes ###

None.

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard